### PR TITLE
Core: JSON-C14N + leaf=sha256(canonical_receipt_bytes) + exports

### DIFF
--- a/packages/tecp-core/src/c14n.ts
+++ b/packages/tecp-core/src/c14n.ts
@@ -1,0 +1,64 @@
+/**
+ * JSON-C14N canonicalization for TECP
+ * - Objects: sort keys ascending (UTF-8)
+ * - Numbers: integers only; floats forbidden
+ * - Strings: UTF-8 JSON encoding
+ * - Output: compact JSON (no spaces, no trailing newline)
+ */
+
+function assertIntegerNumbers(value: unknown): void {
+  if (typeof value === 'number') {
+    if (!Number.isInteger(value)) {
+      throw new Error('Non-integer number encountered in canonicalization');
+    }
+  }
+}
+
+function canonicalizeInternal(value: unknown): unknown {
+  assertIntegerNumbers(value);
+
+  if (value === null || value === undefined) return value as null;
+
+  if (Array.isArray(value)) {
+    return value.map((v) => canonicalizeInternal(v));
+  }
+
+  if (typeof value === 'object') {
+    const obj = value as Record<string, unknown>;
+    const keys = Object.keys(obj).sort((a, b) => a.localeCompare(b, 'en', { sensitivity: 'case' }));
+    const out: Record<string, unknown> = {};
+    for (const k of keys) {
+      out[k] = canonicalizeInternal(obj[k]);
+    }
+    return out;
+  }
+
+  // Primitives: string, boolean, number handled as-is (after integer check above)
+  return value;
+}
+
+export function canonicalJSONString(obj: unknown): string {
+  const canon = canonicalizeInternal(obj);
+  // Default JSON.stringify emits compact JSON without spaces and without trailing newline
+  return JSON.stringify(canon);
+}
+
+export function canonicalBytes(obj: unknown): Uint8Array {
+  const json = canonicalJSONString(obj);
+  return new TextEncoder().encode(json);
+}
+
+// Base64url helpers (no padding)
+export function toBase64Url(bytes: Uint8Array): string {
+  const b64 = Buffer.from(bytes).toString('base64');
+  return b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+export function fromBase64Url(s: string): Uint8Array {
+  // Restore padding
+  const pad = s.length % 4 === 2 ? '==' : s.length % 4 === 3 ? '=' : '';
+  const b64 = s.replace(/-/g, '+').replace(/_/g, '/') + pad;
+  return new Uint8Array(Buffer.from(b64, 'base64'));
+}
+
+

--- a/packages/tecp-core/src/constants.ts
+++ b/packages/tecp-core/src/constants.ts
@@ -1,0 +1,5 @@
+export const SKEW_LITE_MS = 120 * 1000; // 120s
+export const SKEW_STRICT_MS = 10 * 1000; // 10s
+
+export const MAX_RECEIPT_AGE_MS = 24 * 60 * 60 * 1000; // 24h
+

--- a/packages/tecp-core/src/index.ts
+++ b/packages/tecp-core/src/index.ts
@@ -35,8 +35,12 @@ export type { PolicyEnforcer, PolicyContext, PolicyResult } from './policy-runti
 
 // Constants
 export const TECP_VERSION = 'TECP-0.1';
-export const MAX_RECEIPT_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
 export const MAX_CLOCK_SKEW_MS = 5 * 60 * 1000; // 5 minutes
 export const MAX_RECEIPT_SIZE_BYTES = 8192; // 8KB
 export const PERFORMANCE_TARGET_CREATE_MS = 10;
 export const PERFORMANCE_TARGET_VERIFY_MS = 5;
+
+// Canonicalization and leaf hashing
+export { canonicalBytes, canonicalJSONString, toBase64Url, fromBase64Url } from './c14n.js';
+export { leafForLog } from './leaf.js';
+export { SKEW_LITE_MS, SKEW_STRICT_MS, MAX_RECEIPT_AGE_MS } from './constants.js';

--- a/packages/tecp-core/src/leaf.ts
+++ b/packages/tecp-core/src/leaf.ts
@@ -1,0 +1,10 @@
+import { sha256 } from '@noble/hashes/sha256';
+import type { Receipt } from './types.js';
+import { canonicalBytes } from './c14n.js';
+
+export function leafForLog(receipt: Receipt): Uint8Array {
+  const canon = canonicalBytes(receipt);
+  return sha256(canon);
+}
+
+

--- a/spec/LOGGING.md
+++ b/spec/LOGGING.md
@@ -1,0 +1,33 @@
+# TECP Transparency Logging
+
+## Leaf Materialization
+
+- `leaf = sha256(canonical_receipt_bytes)`
+- `canonical_receipt_bytes` are produced via JSON-C14N (sorted keys, integers only, base64url, compact JSON)
+
+## Unified HTTP API
+
+- POST `/v1/log/entries` ->
+```
+{
+  "leaf_index": number,
+  "proof": ["hex", ...],
+  "sth": {"size": number, "root": "hex", "sig": "base64", "kid": "string"},
+  "algo": "sha256",
+  "domain": {"leaf":"00","node":"01"}
+}
+```
+
+- GET `/v1/log/proof?leaf=HEX` -> same structure
+- GET `/v1/log/sth` -> `{ "size": number, "root": "hex", "sig": "base64", "kid": "string" }`
+
+## Merkle Proof Semantics
+
+- Domain separation bytes: `0x00` for leaf, `0x01` for node
+- Proof order: bottom-up siblings, left-to-right semantics
+- Root recomputation: fold over audit path using node hashing
+
+## JWKS
+
+- Log STH signing key is published at `/.well-known/tecp-log-jwks`
+- JWK format: `{ kty: 'OKP', crv: 'Ed25519', x: base64url, kid }`

--- a/spec/PROTOCOL.md
+++ b/spec/PROTOCOL.md
@@ -35,6 +35,24 @@ Receipt {
   pubkey: string (Ed25519 public key, base64)
 }
 ```
+## Canonicalization
+
+All TECP signatures MUST use JSON-C14N canonicalization:
+
+- Objects: keys sorted ascending by UTF-8
+- Numbers: integers only (floats forbidden)
+- Strings: UTF-8 JSON encoding
+- Binary fields: base64url without padding
+- Output: compact JSON (no spaces, no trailing newline)
+
+The canonical bytes are produced by `canonicalBytes(obj)` and used as the signature body. The transparency log leaf for a receipt is defined as:
+
+```
+leaf = sha256(canonical_receipt_bytes)
+```
+
+This rule is frozen to ensure cross-SDK interoperability and verifiability.
+
 
 ### 2.2 Field Definitions
 


### PR DESCRIPTION
Title: Core: JSON-C14N + leaf=sha256(canonical_receipt_bytes) + exports

Why
Deterministic receipts across SDKs; fixed leaf rule for transparency proofs.

What
	•	tecp-core/c14n.ts: JSON-C14N (sorted keys, utf-8, base64url, ints only)
	•	tecp-core/leaf.ts: leafForLog(receipt)
	•	tecp-core/constants.ts: skew constants (LITE ±120s, STRICT ±10s)
	•	tecp-core/receipt.ts: sign/verify over canonical bytes; use skew constants
	•	tecp-core/index.ts: exports

Spec/Docs
	•	spec/PROTOCOL.md#canonicalization (new section)
	•	spec/LOGGING.md (new file; leaf materialization)

Tests
	•	spec/test-vectors/c14n/*, leaf/*
	•	npm run test, npm run test:interop, npm run test:fuzz

Back-compat
LITE unchanged; STRICT depends on canonicalization (documented).

Reviewer checklist
	•	Canon bytes stable (goldens)
	•	Signing uses canonical bytes everywhere
	•	Leaf rule consistent in spec + code
