### PR TITLE
Services: unify /v1/log/entries|proof|sth + log JWKS

### DIFF
--- a/packages/tecp-core/src/c14n.ts
+++ b/packages/tecp-core/src/c14n.ts
@@ -1,0 +1,64 @@
+/**
+ * JSON-C14N canonicalization for TECP
+ * - Objects: sort keys ascending (UTF-8)
+ * - Numbers: integers only; floats forbidden
+ * - Strings: UTF-8 JSON encoding
+ * - Output: compact JSON (no spaces, no trailing newline)
+ */
+
+function assertIntegerNumbers(value: unknown): void {
+  if (typeof value === 'number') {
+    if (!Number.isInteger(value)) {
+      throw new Error('Non-integer number encountered in canonicalization');
+    }
+  }
+}
+
+function canonicalizeInternal(value: unknown): unknown {
+  assertIntegerNumbers(value);
+
+  if (value === null || value === undefined) return value as null;
+
+  if (Array.isArray(value)) {
+    return value.map((v) => canonicalizeInternal(v));
+  }
+
+  if (typeof value === 'object') {
+    const obj = value as Record<string, unknown>;
+    const keys = Object.keys(obj).sort((a, b) => a.localeCompare(b, 'en', { sensitivity: 'case' }));
+    const out: Record<string, unknown> = {};
+    for (const k of keys) {
+      out[k] = canonicalizeInternal(obj[k]);
+    }
+    return out;
+  }
+
+  // Primitives: string, boolean, number handled as-is (after integer check above)
+  return value;
+}
+
+export function canonicalJSONString(obj: unknown): string {
+  const canon = canonicalizeInternal(obj);
+  // Default JSON.stringify emits compact JSON without spaces and without trailing newline
+  return JSON.stringify(canon);
+}
+
+export function canonicalBytes(obj: unknown): Uint8Array {
+  const json = canonicalJSONString(obj);
+  return new TextEncoder().encode(json);
+}
+
+// Base64url helpers (no padding)
+export function toBase64Url(bytes: Uint8Array): string {
+  const b64 = Buffer.from(bytes).toString('base64');
+  return b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+export function fromBase64Url(s: string): Uint8Array {
+  // Restore padding
+  const pad = s.length % 4 === 2 ? '==' : s.length % 4 === 3 ? '=' : '';
+  const b64 = s.replace(/-/g, '+').replace(/_/g, '/') + pad;
+  return new Uint8Array(Buffer.from(b64, 'base64'));
+}
+
+

--- a/packages/tecp-core/src/constants.ts
+++ b/packages/tecp-core/src/constants.ts
@@ -1,0 +1,5 @@
+export const SKEW_LITE_MS = 120 * 1000; // 120s
+export const SKEW_STRICT_MS = 10 * 1000; // 10s
+
+export const MAX_RECEIPT_AGE_MS = 24 * 60 * 60 * 1000; // 24h
+

--- a/packages/tecp-core/src/index.ts
+++ b/packages/tecp-core/src/index.ts
@@ -35,8 +35,12 @@ export type { PolicyEnforcer, PolicyContext, PolicyResult } from './policy-runti
 
 // Constants
 export const TECP_VERSION = 'TECP-0.1';
-export const MAX_RECEIPT_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
 export const MAX_CLOCK_SKEW_MS = 5 * 60 * 1000; // 5 minutes
 export const MAX_RECEIPT_SIZE_BYTES = 8192; // 8KB
 export const PERFORMANCE_TARGET_CREATE_MS = 10;
 export const PERFORMANCE_TARGET_VERIFY_MS = 5;
+
+// Canonicalization and leaf hashing
+export { canonicalBytes, canonicalJSONString, toBase64Url, fromBase64Url } from './c14n.js';
+export { leafForLog } from './leaf.js';
+export { SKEW_LITE_MS, SKEW_STRICT_MS, MAX_RECEIPT_AGE_MS } from './constants.js';

--- a/packages/tecp-core/src/leaf.ts
+++ b/packages/tecp-core/src/leaf.ts
@@ -1,0 +1,10 @@
+import { sha256 } from '@noble/hashes/sha256';
+import type { Receipt } from './types.js';
+import { canonicalBytes } from './c14n.js';
+
+export function leafForLog(receipt: Receipt): Uint8Array {
+  const canon = canonicalBytes(receipt);
+  return sha256(canon);
+}
+
+

--- a/packages/tecp-sdk-js/src/keyring.ts
+++ b/packages/tecp-sdk-js/src/keyring.ts
@@ -1,0 +1,46 @@
+import * as ed25519 from '@noble/ed25519';
+
+export type Jwk = { kty: 'OKP'; crv: 'Ed25519'; x: string; kid?: string };
+export type Jwks = { keys: Jwk[] };
+
+export class Keyring {
+  private kidToKey: Map<string, Uint8Array> = new Map();
+
+  add(kid: string, publicKey: Uint8Array): void {
+    this.kidToKey.set(kid, publicKey);
+  }
+
+  get(kid: string): Uint8Array | undefined {
+    return this.kidToKey.get(kid);
+  }
+
+  static async fromJWKS(url: string): Promise<Keyring> {
+    const res = await fetch(url, { cache: 'no-store' });
+    if (!res.ok) throw new Error(`JWKS fetch failed: ${res.status}`);
+    const jwks = (await res.json()) as Jwks;
+    const kr = new Keyring();
+    for (const jwk of jwks.keys) {
+      if (jwk.kty !== 'OKP' || jwk.crv !== 'Ed25519' || !jwk.x) continue;
+      const kid = jwk.kid || kidFromJwk(jwk);
+      kr.add(kid, base64UrlToBytes(jwk.x));
+    }
+    return kr;
+  }
+}
+
+export function base64UrlToBytes(s: string): Uint8Array {
+  const pad = s.length % 4 === 2 ? '==' : s.length % 4 === 3 ? '=' : '';
+  const b64 = s.replace(/-/g, '+').replace(/_/g, '/') + pad;
+  return new Uint8Array(Buffer.from(b64, 'base64'));
+}
+
+export function kidFromJwk(jwk: Jwk): string {
+  // Derive kid from raw key bytes
+  return toBase64Url(base64UrlToBytes(jwk.x));
+}
+
+export function toBase64Url(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+

--- a/packages/tecp-sdk-js/src/merkle.ts
+++ b/packages/tecp-sdk-js/src/merkle.ts
@@ -1,0 +1,60 @@
+import { sha256 } from '@noble/hashes/sha256';
+
+export function leafHash(data: Uint8Array): Uint8Array {
+  const prefixed = new Uint8Array(1 + data.length);
+  prefixed[0] = 0x00;
+  prefixed.set(data, 1);
+  return sha256(prefixed);
+}
+
+export function nodeHash(left: Uint8Array, right: Uint8Array): Uint8Array {
+  const prefixed = new Uint8Array(1 + left.length + right.length);
+  prefixed[0] = 0x01;
+  prefixed.set(left, 1);
+  prefixed.set(right, 1 + left.length);
+  return sha256(prefixed);
+}
+
+export function verifyAuditPath(
+  leaf: Uint8Array,
+  auditPath: string[], // hex-encoded sibling hashes bottom-up
+  leafIndex: number,
+  expectedRootHex: string,
+  treeSize?: number
+): boolean {
+  let hash = leafHash(leaf);
+
+  for (let i = 0; i < auditPath.length; i++) {
+    const sibling = hexToBytes(auditPath[i]);
+    const isLeft = (leafIndex >> i) & 1;
+    if (isLeft) {
+      hash = nodeHash(sibling, hash);
+    } else {
+      hash = nodeHash(hash, sibling);
+    }
+  }
+
+  const rootHex = bytesToHex(hash);
+  return equalsHex(rootHex, expectedRootHex);
+}
+
+export function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes).map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+export function hexToBytes(hex: string): Uint8Array {
+  const normalized = hex.startsWith('0x') ? hex.slice(2) : hex;
+  const out = new Uint8Array(normalized.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(normalized.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+export function equalsHex(a: string, b: string): boolean {
+  const na = a.startsWith('0x') ? a.slice(2) : a;
+  const nb = b.startsWith('0x') ? b.slice(2) : b;
+  return na.toLowerCase() === nb.toLowerCase();
+}
+
+


### PR DESCRIPTION
Title: Services: unify /v1/log/entries|proof|sth + log JWKS

Why
One client contract; verifiable STHs.

What
	•	tecp-log + tecp-ledger: normalized responses to unified schema
	•	/.well-known/tecp-log-jwks served by both

API

POST /v1/log/entries -> {
  "leaf_index": n,
  "proof": ["hex", ...],
  "sth": {"size": m, "root": "hex", "sig": "b64", "kid": "log-key-1"},
  "algo": "sha256",
  "domain": {"leaf":"00","node":"01"}
}
GET /v1/log/proof?leaf=HEX -> same
GET /v1/log/sth -> {"size": m, "root":"hex", "sig":"b64", "kid":"log-key-1"}

Spec/Docs
	•	spec/LOGGING.md examples + schemas

Tests
	•	Interop: proofs from each service verify in SDK
	•	STH validates against JWKS

Back-compat
Old endpoints deprecated (warn), removable next minor.

Reviewer checklist
	•	Shapes identical across services
	•	STH signed and verifiable
	•	Proof order/domain match SDK
